### PR TITLE
Lock specific version of psp-types to avoid serde issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ jsonrpc-lite = "0.5.0"
 
 [dependencies.psp-types]
 git = "https://github.com/lapce/psp-types"
-branch = "master"
+rev = "2513ff3c510377b2c2a003892d07bc91bec00c7a"


### PR DESCRIPTION
Since the attached PR wasn't merged in lapce, it caused serde issue anywhere `execute_process` is used.

See: https://github.com/lapce/lapce/pull/2091


Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>