### PR TITLE
Send request/notifications to lsp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use psp_types::{
         DocumentSelector, LogMessageParams, MessageType, ShowMessageParams, Url,
     },
     ExecuteProcess, ExecuteProcessParams, ExecuteProcessResult, Notification, Request,
-    StartLspServer, StartLspServerParams,
+    StartLspServer, StartLspServerParams, StartLspServerResult,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
@@ -180,8 +180,8 @@ impl PluginServerRpcHandler {
         server_args: Vec<String>,
         document_selector: DocumentSelector,
         options: Option<Value>,
-    ) -> Result<(), PluginError> {
-        self.host_notification(
+    ) -> Result<StartLspServerResult, PluginError> {
+        self.host_request(
             StartLspServer::METHOD,
             StartLspServerParams {
                 server_uri,

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,0 +1,30 @@
+use psp_types::LspId;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{PluginError, PLUGIN_RPC};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LspRef {
+    pub id: LspId,
+}
+impl LspRef {
+    pub fn new(id: LspId) -> Self {
+        Self { id }
+    }
+
+    pub fn send_request_blocking<P: Serialize, D: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<D, PluginError> {
+        PLUGIN_RPC.lsp_send_request_blocking(self.id, method, params)
+    }
+
+    pub fn send_notification<P: Serialize>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<(), PluginError> {
+        PLUGIN_RPC.lsp_send_notification(self.id, method, params)
+    }
+}


### PR DESCRIPTION
This makes so starting an lsp returns an `LspRef`.  
This just provides utility functions to make talking to the LSP simpler, but it will just use `PLUGIN_RPC` under the hood.  
  
I've marked the functions with the suffix `lsp_send_request_blocking` because I expect that in the future we'll want to make callback (or rust's `async`? eh) based versions, since a plugin shouldn't stall out if the lsp is being slow to reply. 